### PR TITLE
refactor: remove flagLazy logic and finalize Lazy API removal

### DIFF
--- a/api.go
+++ b/api.go
@@ -67,14 +67,6 @@ func CtxSubmit[T any](ctx context.Context, e Executor, f func(ctx context.Contex
 	return &Future[T]{state: s}
 }
 
-// Lazy Deprecated, will be removed in later version
-func Lazy[T any](f func() (T, error)) *Future[T] {
-	s := &state[T]{}
-	s.state |= flagLazy
-	s.f = f
-	return &Future[T]{state: s}
-}
-
 func Done[T any](val T) *Future[T] {
 	return Done2(val, nil)
 }

--- a/api_test.go
+++ b/api_test.go
@@ -6,7 +6,6 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -70,37 +69,6 @@ func TestSetExecutor(t *testing.T) {
 	assert.Panics(t, func() {
 		SetExecutor(nil)
 	})
-}
-
-func TestLazy(t *testing.T) {
-	f := Lazy(func() (int, error) {
-		return 1, nil
-	})
-	val, err := f.Get()
-	assert.Equal(t, 1, val)
-	assert.Equal(t, nil, err)
-}
-
-func TestLazyConcurrency(t *testing.T) {
-	n := runtime.NumCPU() - 1
-
-	var counter int32
-	f := Lazy(func() (int, error) {
-		c := atomic.AddInt32(&counter, 1)
-		return int(c), nil
-	})
-
-	wg := sync.WaitGroup{}
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			val, err := f.Get()
-			assert.Equal(t, val, 1)
-			assert.Equal(t, err, nil)
-		}()
-	}
-	wg.Wait()
 }
 
 func TestDone(t *testing.T) {


### PR DESCRIPTION
**This PR removes all flagLazy handling and related logic, finalizing the removal of the Lazy API in this version.**

### ⚠️ Deprecation Notice: Lazy
The Lazy API is deprecated and has been removed in this version.

Although Lazy provided deferred execution semantics, it introduced implicit pull-based dependencies that were difficult to reason about. Unlike Async, where execution is guaranteed upon construction, Lazy deferred execution until .Get() was called—often far from the definition site.

This subtle semantic difference:

- Made control flow harder to predict
- Broke intuitive data dependency modeling
- Could cause unexpected bugs when chained or composed concurrently

Recommendation: Use Async or Promise APIs instead, which are explicit and deterministic.