### PR TITLE
feat: Add `Freeze` method doc for `dagcore` and `dagfunc`

### DIFF
--- a/dagfunc/dagfunc_test.go
+++ b/dagfunc/dagfunc_test.go
@@ -45,6 +45,7 @@ func TestDagFuncFlow(t *testing.T) {
 	assert.NoError(t, builder.Use(fnC))
 	assert.NoError(t, builder.Use(fnD))
 
+	assert.NoError(t, builder.Freeze())
 	inst, err := builder.Compile([]any{InputA{Value: 10}, InputB{Text: "hello"}})
 	assert.NoError(t, err)
 
@@ -78,6 +79,7 @@ func TestDagFuncFlowError(t *testing.T) {
 	assert.NoError(t, builder.Use(func(ctx context.Context, a InputA, b InputB) (ResultC, error) {
 		return ResultC{}, errors.New("fault")
 	}))
+	assert.NoError(t, builder.Freeze())
 	prog, err := builder.Compile([]any{InputA{}, InputB{}})
 	assert.NoError(t, err)
 	ctx := context.Background()


### PR DESCRIPTION
## ✨ feat: Add `Freeze` method doc for `dagcore` and `dagfunc`

### 📄 Changes

* **\[dagcore]**

  * Added explicit `Freeze()` step in the public API doc (`README.md`).
  * Clarified that `Freeze` ensures the DAG is complete and acyclic before execution.
  * Added minimal usage example showing `NewDAG` → `AddNode` → `Freeze` → `Instantiate`.

* **\[dagfunc]**

  * Added `Freeze()` step description to clarify internal builder compilation flow.
  * Mentioned that `dagfunc` internally calls `dagcore.Freeze` during `Compile()`.
  * Improved readability of the `API Overview` section to show the static structure lock step.

---

### 📚 Motivation

In the current README, the DAG execution section (`dagcore` and `dagfunc`) did not explicitly mention the `Freeze` step, which is critical for:

✅ Ensuring immutability: prevents accidental changes after the graph structure is validated.

✅ Ensuring correctness: guarantees no missing dependencies or cyclic references.

✅ Reducing redundant checks: Freeze performs validation once and locks the topology, avoiding repeated checks at each instantiation.

✅ Safe reuse: multiple DAG executions can share the same validated structure without re-checking.


Making this explicit helps users avoid runtime errors like ErrDAGNotFrozen and clarifies the recommended pattern for repeatable, efficient, and safe DAG executions.

---

### ✅ What’s updated

#### 🧩 `dagcore`

**Before:**

```go
dag := dagcore.NewDAG()
_ = dag.AddInput("A")
_ = dag.AddNode("B", []dagcore.NodeID{"A"}, ...)
inst, _ := dag.Instantiate(...) // ⛔ may fail if not frozen
```

**After:**

```go
dag := dagcore.NewDAG()
_ = dag.AddInput("A")
_ = dag.AddNode("B", []dagcore.NodeID{"A"}, ...)
_ = dag.Freeze() // ✅ freeze for safety & repeatable execution
inst, _ := dag.Instantiate(...)
```