### PR TITLE
feat: gate generic methods behind //go:build go1.27, restore Go 1.18 support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,20 +13,27 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 1.18 is the minimum version in go.mod and exercises the build without
+        # generic methods; 1.27 compiles the //go:build go1.27 files.
+        go-version: ['1.18', '1.27']
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.27'
+        go-version: ${{ matrix.go-version }}
 
     - name: golangci-lint
+      # golangci-lint only supports Go versions lower than or equal to the one
+      # it was built with, so it can only run on the newest job.
+      # See https://github.com/golangci/golangci-lint/issues/6643
+      if: matrix.go-version == '1.27'
       uses: golangci/golangci-lint-action@v9.3.0
       with:
-        # golangci-lint only supports Go versions lower than or equal to the one
-        # it was built with, so this must be a release built with go1.27 or newer.
-        # See https://github.com/golangci/golangci-lint/issues/6643
         version: v2.13.2
         args: --timeout=5m
 
@@ -34,6 +41,7 @@ jobs:
       run: go test -race -coverprofile=coverage.out -covermode=atomic -v ./...
 
     - name: Upload coverage reports to Codecov
+      if: matrix.go-version == '1.27'
       uses: codecov/codecov-action@v4.0.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,19 +12,13 @@
 - Task composition (`AllOf`, `AnyOf`)
 - Timeout control (`Timeout`, `Until`)
 - Full support for Go generics
-- **Fluent combinators as generic methods** (`Then[R]`, `Map[R]`, `FlatMap[R]`, `Cast[R]`, ...)
+- **Fluent combinators as generic methods** (`Then[R]`, `Map[R]`, `FlatMap[R]`, `Cast[R]`, ...) — Go 1.27+
 
 ## 🔧 Requirements
 
-| go-future   | Go    |
-| ----------- | ----- |
-| `>= v0.2.0` | 1.27+ |
-| `<= v0.1.6` | 1.18+ |
+**Go 1.18 or newer.** The module declares `go 1.18` and stays compatible with every release since.
 
-v0.2.0 declares `go 1.27` in `go.mod` because the combinators are exposed as
-**generic methods**. See [Go 1.27 release notes](https://go.dev/doc/go1.27).
-With `GOTOOLCHAIN=auto` (the default) older toolchains download Go 1.27
-automatically.
+The generic methods (`Then[R]`, `Map[R]`, `Cast[R]`, …) are an optional enhancement compiled only when the toolchain is **Go 1.27 or newer**, guarded by `//go:build go1.27`. On older toolchains the package-level functions provide the same capabilities, so no upgrade is ever required. See [Go 1.27 release notes](https://go.dev/doc/go1.27).
 
 ## 🔧 Installation
 
@@ -36,16 +30,9 @@ go get github.com/jizhuozhi/go-future
 
 ## ⬆️ Migrating to v0.2.0
 
-v0.2.0 is the first release built on Go 1.27 **generic methods**. It is a
-breaking release: two groups of symbols moved, everything else is additive.
+v0.2.0 adds generic methods on top of the existing API. Exactly one group of symbols moved; everything else is additive and **no Go upgrade is required**.
 
-### 1. Go 1.27 or newer
-
-`go.mod` now declares `go 1.27`. Nothing to change in your code; with
-`GOTOOLCHAIN=auto` the toolchain is fetched for you, otherwise upgrade manually.
-Staying on Go 1.18–1.26 means staying on go-future `v0.1.6`.
-
-### 2. Tuples moved to the `tuples` subpackage
+### 1. Tuples moved to the `tuples` subpackage (breaking)
 
 `Tuple2`…`Tuple16` and `Of2`…`Of16` are rarely used and added 30 exported
 symbols to the main package, so they now live in their own package:
@@ -65,35 +52,38 @@ t, err := f.Get()
 There is deliberately no alias left behind in `future`: `tuples` imports
 `future`, so keeping one would create an import cycle.
 
-### 3. Everything else is source compatible
+### 2. No Go upgrade required
 
-The package-level single-Future transforms still work, they are only marked
-`Deprecated:` to point at the new method form. Migrating is optional and
-mechanical:
+The module still declares `go 1.18`. The generic methods live in files guarded by `//go:build go1.27`, which tests the **toolchain** version rather than the `go` directive, so they light up automatically without touching `go.mod`.
 
-| Deprecated         | Preferred        |
-| ------------------ | ---------------- |
-| `Then(f, cb)`      | `f.Then(cb)`     |
+| Toolchain      | What compiles                                             |
+| -------------- | --------------------------------------------------------- |
+| Go 1.18 – 1.26 | package-level functions only: `Then(f, cb)`, `Timeout(f, d)`, … |
+| Go 1.27+       | both forms: `f.Then(cb)` **and** `Then(f, cb)`            |
+
+### 3. Package-level functions are not deprecated
+
+They remain a fully supported API, not a compatibility shim. The two forms do **not** delegate to each other, by design: the package-level functions must not depend on a file that can be excluded from the build, so each variant carries its own (small, self-contained) body.
+
+| Function           | Method form       |
+| ------------------ | ----------------- |
+| `Then(f, cb)`      | `f.Then(cb)`      |
 | `ThenAsync(f, cb)` | `f.ThenAsync(cb)` |
-| `ToAny(f)`         | `f.ToAny()`      |
-| `ToChan(f)`        | `f.ToChan()`     |
-| `Timeout(f, d)`    | `f.Timeout(d)`   |
-| `Until(f, t)`      | `f.Until(t)`     |
-| `Await(f)`         | `f.Get()`        |
+| `ToAny(f)`         | `f.ToAny()`       |
+| `ToChan(f)`        | `f.ToChan()`      |
+| `Timeout(f, d)`    | `f.Timeout(d)`    |
+| `Until(f, t)`      | `f.Until(t)`      |
+| `Await(f)`         | `f.Get()`         |
 
-`AllOf`, `AnyOf`, `Async`, `Done`, `NewPromise` and all `Promise` / `Future`
-methods are unchanged.
+`AllOf`, `AnyOf`, `Async`, `Done`, `NewPromise` and all `Promise` / `Future` methods are unchanged.
 
-### New in v0.2.0
+### New in v0.2.0 (Go 1.27+)
 
-* Single-Future transforms as generic methods: `Then[R]`, `ThenAsync[R]`,
-  `ThenGo[R]`, `Map[R]`, `FlatMap[R]`, `Cast[R]`, `Recover`, `OrElse`.
-* `dagcore.NodeInstance.Cast[T]` and `dagfunc.Program.Value[T]` /
-  `ValueAsync[T]` for reading `any`-typed results without assertions.
+* Single-Future transforms as generic methods: `Then[R]`, `ThenAsync[R]`, `ThenGo[R]`, `Map[R]`, `FlatMap[R]`, `Cast[R]`, `Recover`, `OrElse`.
+* `dagcore.NodeInstance.Cast[T]` and `dagfunc.Program.Value[T]` / `ValueAsync[T]` for reading `any`-typed results without assertions.
 * `future.ErrTypeMismatch` for failed `Cast` conversions.
 
-`dagfunc.Program.Get(sample any)` is **unchanged** — `Value[T]` is the new,
-type-safe alternative, not a replacement.
+`dagfunc.Program.Get(sample any)` is **unchanged** — `Value[T]` is a type-safe alternative, not a replacement.
 
 ---
 
@@ -142,13 +132,11 @@ One rule decides whether an operation is a package-level function or a method:
 | Single-Future transform    | **method**  | `Then`, `ThenAsync`, `ThenGo`, `Map`, `FlatMap`, `Cast`, `Recover`, `OrElse`, `ToAny`, `ToChan`, `Timeout`, `Until` |
 | Combinator over N Futures  | function    | `AllOf`, `AnyOf`                                                                                                  |
 
-A transform that changes the result type must introduce a type parameter of its
-own, so until Go 1.27 it could only live at package scope. A combinator over
-several Futures has no single receiver, and the language forbids a generic
-method from returning its receiver's type instantiated with a receiver-derived
-type (see the restrictions below) — so combinators stay functions. Java, Scala
-and friends draw the same line: "zip N futures into one" is a static/companion
-function there as well.
+A transform that changes the result type must introduce a type parameter of its own, so until Go 1.27 it could only live at package scope. Since Go 1.27 it can be a method, and the method form is what you want to reach for: it chains left-to-right and it is discoverable through completion.
+
+Both forms coexist. The methods are compiled only under a Go 1.27+ toolchain (`//go:build go1.27`); the package-level functions are always available, which is what keeps Go 1.18 working.
+
+A combinator over several Futures has no single receiver, and the language forbids a generic method from returning its receiver's type instantiated with a receiver-derived type (see the restrictions below) — so combinators stay functions. Java, Scala and friends draw the same line: "zip N futures into one" is a static/companion function there as well.
 
 `AllOf` / `AnyOf` cover batches of Futures that share a type. Zipping Futures of
 **unrelated** types needs one function per arity, so `Tuple2`…`Tuple16` and
@@ -192,6 +180,8 @@ val, _ := p.Future().Get()
 ---
 
 ### Single-Future transforms — `*Future[T]` methods
+
+> **Requires a Go 1.27+ toolchain.** These files are guarded by `//go:build go1.27`. On Go 1.18–1.26 the package-level functions below provide the same capabilities.
 
 Go 1.27 lets a **method declare its own type parameters**, so transforms live on
 `*Future[T]` and a pipeline reads left-to-right instead of inside-out.
@@ -248,21 +238,19 @@ count, err := inst.Nodes()["func:TokenCount"].Cast[TokenCount]().Get()
 
 ---
 
-### Deprecated package-level transforms
+### Package-level transforms (all Go versions)
 
-These only existed because a method could not declare its own type parameters
-before Go 1.27. They still work and delegate to the methods above, but new code
-should use the method form.
+These are the original API and the only form available on Go 1.18–1.26. They are **not** deprecated, and they do not delegate to the methods above: each variant carries its own implementation so that the Go 1.18 build has no dependency on a file that may be excluded from it.
 
-| Deprecated       | Use instead       |
-| ---------------- | ----------------- |
-| `Then(f, cb)`    | `f.Then(cb)`      |
-| `ThenAsync(f, cb)` | `f.ThenAsync(cb)` |
-| `ToAny(f)`       | `f.ToAny()`       |
-| `ToChan(f)`      | `f.ToChan()`      |
-| `Timeout(f, d)`  | `f.Timeout(d)`    |
-| `Until(f, t)`    | `f.Until(t)`      |
-| `Await(f)`       | `f.Get()`         |
+| Function           | Method form (Go 1.27+) |
+| ------------------ | ---------------------- |
+| `Then(f, cb)`      | `f.Then(cb)`           |
+| `ThenAsync(f, cb)` | `f.ThenAsync(cb)`      |
+| `ToAny(f)`         | `f.ToAny()`            |
+| `ToChan(f)`        | `f.ToChan()`           |
+| `Timeout(f, d)`    | `f.Timeout(d)`         |
+| `Until(f, t)`      | `f.Until(t)`           |
+| `Await(f)`         | `f.Get()`              |
 
 ---
 
@@ -457,9 +445,9 @@ _ = dag.Freeze()
 
 #### `(*NodeInstance).Cast[T any]() *future.Future[T]`
 
-Returns the result of a single node as a typed Future, using the generic methods
-introduced in Go 1.27. Fails with `future.ErrTypeMismatch` if the produced value
-is not assignable to `T`.
+Returns the result of a single node as a typed Future, using the generic methods introduced in Go 1.27. Fails with `future.ErrTypeMismatch` if the produced value is not assignable to `T`.
+
+> **Requires a Go 1.27+ toolchain** — the file is guarded by `//go:build go1.27`. Use `NodeInstance.Future()` and assert manually on older versions.
 
 ```go
 count, err := inst.Nodes()["func:TokenCount"].Cast[TokenCount]().Get()
@@ -662,6 +650,8 @@ count, err := prog.Get(TokenCount(0)) // count is an any, needs an assertion
 ```
 
 #### `(*Program).Value[T any]() (T, error)`
+
+> **Requires a Go 1.27+ toolchain**, as do `ValueAsync[T]`. `Get(sample any)` is the version-independent alternative.
 
 Gets the typed result value produced by the node whose result type is `T`.
 Blocked until that node completes, so `Run` / `RunAsync` must have been called.

--- a/api.go
+++ b/api.go
@@ -133,57 +133,79 @@ func AllOf[T any](fs ...*Future[T]) *Future[[]T] {
 	return &Future[[]T]{state: s}
 }
 
-// Deprecated single-Future transforms, kept for source compatibility. They
-// delegate to the methods on *Future[T], which hold the only implementation;
-// see the package documentation for the layering rule.
+// Single-Future transforms. These are the original package-level API and are
+// compiled on every supported Go version, including Go 1.18.
+//
+// Each one carries its own implementation rather than delegating to the method
+// form in method.go, because that file is only built when the toolchain is Go
+// 1.27 or newer. Duplicating the small bodies keeps the two variants completely
+// independent, so the Go 1.18 build has no dependency on generic methods at all.
 
 // Await blocks until f is resolved.
-//
-// Deprecated: it is a pure alias for f.Get(), use that instead.
 func Await[T any](f *Future[T]) (T, error) {
 	return f.Get()
 }
 
 // Then chains a synchronous computation onto f.
-//
-// Deprecated: use f.Then(cb).
 func Then[T any, R any](f *Future[T], cb func(T, error) (R, error)) *Future[R] {
-	return f.Then(cb)
+	s := &state[R]{}
+	f.state.subscribe(func(val T, err error) {
+		rval, rerr := cb(val, err)
+		s.set(rval, rerr)
+	})
+	return &Future[R]{state: s}
 }
 
 // ThenAsync chains an asynchronous computation onto f.
-//
-// Deprecated: use f.ThenAsync(cb).
 func ThenAsync[T any, R any](f *Future[T], cb func(T, error) *Future[R]) *Future[R] {
-	return f.ThenAsync(cb)
+	s := &state[R]{}
+	f.state.subscribe(func(val T, err error) {
+		cb(val, err).state.subscribe(func(rval R, rerr error) {
+			s.set(rval, rerr)
+		})
+	})
+	return &Future[R]{state: s}
 }
 
 // ToAny widens f into a *Future[any].
-//
-// Deprecated: use f.ToAny().
 func ToAny[T any](f *Future[T]) *Future[any] {
-	return f.ToAny()
+	return Then(f, func(val T, err error) (any, error) {
+		return val, err
+	})
 }
 
 // ToChan converts f into a single read-only channel of Result[T].
-//
-// Deprecated: use f.ToChan().
 func ToChan[T any](f *Future[T]) <-chan Result[T] {
-	return f.ToChan()
+	ch := make(chan Result[T], 1)
+	f.Subscribe(func(val T, err error) {
+		ch <- Result[T]{Val: val, Err: err}
+		close(ch)
+	})
+	return ch
 }
 
 // Timeout wraps f so that it fails with ErrTimeout when it is not resolved
 // within d.
-//
-// Deprecated: use f.Timeout(d).
 func Timeout[T any](f *Future[T], d time.Duration) *Future[T] {
-	return f.Timeout(d)
+	var done uint32
+	s := &state[T]{}
+	timer := time.AfterFunc(d, func() {
+		if atomic.CompareAndSwapUint32(&done, 0, 1) {
+			var zero T
+			s.set(zero, ErrTimeout)
+		}
+	})
+	f.state.subscribe(func(val T, err error) {
+		if atomic.CompareAndSwapUint32(&done, 0, 1) {
+			s.set(val, err)
+			timer.Stop()
+		}
+	})
+	return &Future[T]{state: s}
 }
 
 // Until wraps f so that it fails with ErrTimeout when it is not resolved before
 // t.
-//
-// Deprecated: use f.Until(t).
 func Until[T any](f *Future[T], t time.Time) *Future[T] {
-	return f.Until(t)
+	return Timeout(f, time.Until(t))
 }

--- a/dagcore/cast.go
+++ b/dagcore/cast.go
@@ -1,0 +1,21 @@
+//go:build go1.27
+
+package dagcore
+
+import (
+	"github.com/jizhuozhi/go-future"
+)
+
+// Cast returns the result of the node as a *future.Future[T].
+//
+// Node results are carried as `any` because a DAG is built dynamically; Cast is
+// the typed bridge back to static types. It relies on the generic methods
+// introduced in Go 1.27, which let a method declare its own type parameters.
+//
+//	count, err := inst.Nodes()["func:TokenCount"].Cast[TokenCount]().Get()
+//
+// If the node fails, the error is propagated. If the produced value is not
+// assignable to T, the returned Future fails with future.ErrTypeMismatch.
+func (n *NodeInstance) Cast[T any]() *future.Future[T] {
+	return n.future.Cast[T]()
+}

--- a/dagcore/cast_test.go
+++ b/dagcore/cast_test.go
@@ -1,0 +1,36 @@
+//go:build go1.27
+
+package dagcore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jizhuozhi/go-future"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDAG_NodeCast exercises the generic method NodeInstance.Cast (Go 1.27+).
+func TestDAG_NodeCast(t *testing.T) {
+	dag := NewDAG()
+	assert.NoError(t, dag.AddNode("A", nil, func(ctx context.Context, _ map[NodeID]any) (any, error) {
+		return 42, nil
+	}))
+	assert.NoError(t, dag.Freeze())
+	inst, err := dag.Instantiate(nil)
+	assert.NoError(t, err)
+
+	// Cast is non-blocking, it can be obtained before the DAG is started.
+	f := inst.Nodes()["A"].Cast[int]()
+
+	_, err = inst.Run(context.Background())
+	assert.NoError(t, err)
+
+	val, err := f.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, 42, val)
+
+	// A mismatching type is reported instead of panicking.
+	_, err = inst.Nodes()["A"].Cast[string]().Get()
+	assert.ErrorIs(t, err, future.ErrTypeMismatch)
+}

--- a/dagcore/dagcore.go
+++ b/dagcore/dagcore.go
@@ -296,20 +296,6 @@ func (n *NodeInstance) Subgraph() *DAGInstance      { return n.subgraph }
 func (n *NodeInstance) Future() *future.Future[any] { return n.future }
 func (n *NodeInstance) Duration() time.Duration     { return n.duration }
 
-// Cast returns the result of the node as a *future.Future[T].
-//
-// Node results are carried as `any` because a DAG is built dynamically; Cast is
-// the typed bridge back to static types. It relies on the generic methods
-// introduced in Go 1.27, which let a method declare its own type parameters.
-//
-//	count, err := inst.Nodes()["func:TokenCount"].Cast[TokenCount]().Get()
-//
-// If the node fails, the error is propagated. If the produced value is not
-// assignable to T, the returned Future fails with future.ErrTypeMismatch.
-func (n *NodeInstance) Cast[T any]() *future.Future[T] {
-	return n.future.Cast[T]()
-}
-
 // DAGInstance is the per-execution runtime of a DAG
 type DAGInstance struct {
 	spec     *DAG
@@ -338,7 +324,7 @@ func (d *DAGInstance) RunAsync(ctx context.Context) *future.Future[map[NodeID]an
 		d.schedule(ctx, id)
 	}
 
-	f := future.AllOf(futures...).Then(func(_ []any, err error) (map[NodeID]any, error) {
+	f := future.Then(future.AllOf(futures...), func(_ []any, err error) (map[NodeID]any, error) {
 		if err != nil {
 			for _, n := range d.nodes {
 				if !n.future.Done() {

--- a/dagcore/dagcore_test.go
+++ b/dagcore/dagcore_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jizhuozhi/go-future"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,31 +30,6 @@ func TestDAG_SimpleExecution(t *testing.T) {
 	assert.Equal(t, "ab", res["B"])
 
 	assert.Equal(t, dag, inst.Spec())
-}
-
-// TestDAG_NodeCast exercises the generic method NodeInstance.Cast (Go 1.27+).
-func TestDAG_NodeCast(t *testing.T) {
-	dag := NewDAG()
-	assert.NoError(t, dag.AddNode("A", nil, func(ctx context.Context, _ map[NodeID]any) (any, error) {
-		return 42, nil
-	}))
-	assert.NoError(t, dag.Freeze())
-	inst, err := dag.Instantiate(nil)
-	assert.NoError(t, err)
-
-	// Cast is non-blocking, it can be obtained before the DAG is started.
-	f := inst.Nodes()["A"].Cast[int]()
-
-	_, err = inst.Run(context.Background())
-	assert.NoError(t, err)
-
-	val, err := f.Get()
-	assert.NoError(t, err)
-	assert.Equal(t, 42, val)
-
-	// A mismatching type is reported instead of panicking.
-	_, err = inst.Nodes()["A"].Cast[string]().Get()
-	assert.ErrorIs(t, err, future.ErrTypeMismatch)
 }
 
 func TestDAG_SimpleWrapExecution(t *testing.T) {

--- a/dagfunc/dagfunc.go
+++ b/dagfunc/dagfunc.go
@@ -159,7 +159,7 @@ func (p *Program) Run(ctx context.Context) (map[any]any, error) {
 // RunAsync executes the DAG and returns the results.
 // The results are keyed by a zero-value sample of their output type for ergonomic lookup.
 func (p *Program) RunAsync(ctx context.Context) *future.Future[map[any]any] {
-	f := p.execution.RunAsync(ctx).Then(func(values map[dagcore.NodeID]any, err error) (map[any]any, error) {
+	f := future.Then(p.execution.RunAsync(ctx), func(values map[dagcore.NodeID]any, err error) (map[any]any, error) {
 		res := make(map[any]any)
 		if err != nil {
 			return nil, err
@@ -176,7 +176,8 @@ func (p *Program) RunAsync(ctx context.Context) *future.Future[map[any]any] {
 // Get returns the output value of a node that produces the given sample's type.
 // The sample is only used to determine the type.
 //
-// Prefer Value[T], which is type safe and needs no sample value.
+// On Go 1.27 and newer, Value[T] is a type-safe alternative that needs no
+// sample value and no type assertion.
 func (p *Program) Get(sample any) (any, error) {
 	typ := reflect.TypeOf(sample)
 	id, ok := p.builder.typeToID[typ]
@@ -184,40 +185,6 @@ func (p *Program) Get(sample any) (any, error) {
 		return nil, ErrTypeNotFound
 	}
 	return p.execution.Nodes()[id].Future().Get()
-}
-
-// ValueAsync returns the output of the node producing T as a Future, without
-// blocking. The returned Future is resolved when that node completes, so it has
-// to be triggered by Run or RunAsync first.
-//
-// Thanks to generic methods (Go 1.27) the result type is expressed as a method
-// type parameter, which removes both the throw-away sample value and the type
-// assertion needed by Get:
-//
-//	go prog.Run(ctx)
-//	c, err := prog.ValueAsync[ResultC]().Get()
-//
-// If no node produces T the Future fails immediately with ErrTypeNotFound; if
-// the produced value is not assignable to T it fails with future.ErrTypeMismatch.
-func (p *Program) ValueAsync[T any]() *future.Future[T] {
-	var zero T
-	typ := reflect.TypeFor[T]()
-	id, ok := p.builder.typeToID[typ]
-	if !ok {
-		return future.Done2(zero, fmt.Errorf("%w: %v", ErrTypeNotFound, typ))
-	}
-	return p.execution.Nodes()[id].Cast[T]()
-}
-
-// Value returns the output of the node producing T, blocking until that node
-// completes.
-//
-// The program must have been started with Run or RunAsync, otherwise Value
-// blocks forever.
-//
-//	c, err := prog.Value[ResultC]()
-func (p *Program) Value[T any]() (T, error) {
-	return p.ValueAsync[T]().Get()
 }
 
 func fullTypeName(t reflect.Type) string {

--- a/dagfunc/dagfunc_test.go
+++ b/dagfunc/dagfunc_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jizhuozhi/go-future"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -72,55 +71,6 @@ func TestDagFuncFlow(t *testing.T) {
 	dVal2, err := inst.Get(ResultD{})
 	assert.NoError(t, err)
 	assert.Equal(t, ResultD{Message: "Sum is \x0f"}, dVal2.(ResultD))
-
-	// Value[T] is the type safe form.
-	cVal3, err := inst.Value[ResultC]()
-	assert.NoError(t, err)
-	assert.Equal(t, ResultC{Sum: 15}, cVal3)
-}
-
-type Unregistered struct{}
-
-// TestDagFuncGenericGet exercises the generic methods introduced with Go 1.27.
-func TestDagFuncGenericGet(t *testing.T) {
-	builder := New()
-
-	assert.NoError(t, builder.Provide(InputA{}))
-	assert.NoError(t, builder.Provide(InputB{}))
-	assert.NoError(t, builder.Use(fnC))
-	assert.NoError(t, builder.Use(fnD))
-	assert.NoError(t, builder.Freeze())
-
-	prog, err := builder.Compile([]any{InputA{Value: 10}, InputB{Text: "hello"}})
-	assert.NoError(t, err)
-
-	// ValueAsync does not block, it can be subscribed before the DAG is started.
-	fc := prog.ValueAsync[ResultC]()
-	fd := prog.ValueAsync[ResultD]()
-
-	_, err = prog.Run(context.Background())
-	assert.NoError(t, err)
-
-	c, err := fc.Get()
-	assert.NoError(t, err)
-	assert.Equal(t, ResultC{Sum: 15}, c)
-
-	d, err := fd.Get()
-	assert.NoError(t, err)
-	assert.Equal(t, ResultD{Message: "Sum is \x0f"}, d)
-
-	// After the DAG completed, Value returns the very same values.
-	c2, err := prog.Value[ResultC]()
-	assert.NoError(t, err)
-	assert.Equal(t, c, c2)
-
-	// An unregistered type is reported eagerly, without executing anything.
-	_, err = prog.ValueAsync[Unregistered]().Get()
-	assert.ErrorIs(t, err, ErrTypeNotFound)
-
-	// Casting a node result to an unrelated type fails with ErrTypeMismatch.
-	_, err = prog.ValueAsync[ResultC]().Cast[ResultD]().Get()
-	assert.ErrorIs(t, err, future.ErrTypeMismatch)
 }
 
 func TestDagFuncFlowError(t *testing.T) {

--- a/dagfunc/value.go
+++ b/dagfunc/value.go
@@ -1,0 +1,46 @@
+//go:build go1.27
+
+package dagfunc
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/jizhuozhi/go-future"
+)
+
+// ValueAsync returns the output of the node producing T as a Future, without
+// blocking. The returned Future is resolved when that node completes, so it has
+// to be triggered by Run or RunAsync first.
+//
+// Thanks to generic methods (Go 1.27) the result type is expressed as a method
+// type parameter, which removes both the throw-away sample value and the type
+// assertion needed by Get:
+//
+//	go prog.Run(ctx)
+//	c, err := prog.ValueAsync[ResultC]().Get()
+//
+// If no node produces T the Future fails immediately with ErrTypeNotFound; if
+// the produced value is not assignable to T it fails with future.ErrTypeMismatch.
+func (p *Program) ValueAsync[T any]() *future.Future[T] {
+	var zero T
+	// reflect.TypeFor[T]() would be clearer but is Go 1.22+, and this file must
+	// stay buildable under the module's declared language version.
+	typ := reflect.TypeOf((*T)(nil)).Elem()
+	id, ok := p.builder.typeToID[typ]
+	if !ok {
+		return future.Done2(zero, fmt.Errorf("%w: %v", ErrTypeNotFound, typ))
+	}
+	return p.execution.Nodes()[id].Cast[T]()
+}
+
+// Value returns the output of the node producing T, blocking until that node
+// completes.
+//
+// The program must have been started with Run or RunAsync, otherwise Value
+// blocks forever.
+//
+//	c, err := prog.Value[ResultC]()
+func (p *Program) Value[T any]() (T, error) {
+	return p.ValueAsync[T]().Get()
+}

--- a/dagfunc/value_test.go
+++ b/dagfunc/value_test.go
@@ -1,0 +1,55 @@
+//go:build go1.27
+
+package dagfunc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jizhuozhi/go-future"
+	"github.com/stretchr/testify/assert"
+)
+
+type Unregistered struct{}
+
+// TestDagFuncGenericGet exercises the generic methods introduced with Go 1.27.
+func TestDagFuncGenericGet(t *testing.T) {
+	builder := New()
+
+	assert.NoError(t, builder.Provide(InputA{}))
+	assert.NoError(t, builder.Provide(InputB{}))
+	assert.NoError(t, builder.Use(fnC))
+	assert.NoError(t, builder.Use(fnD))
+	assert.NoError(t, builder.Freeze())
+
+	prog, err := builder.Compile([]any{InputA{Value: 10}, InputB{Text: "hello"}})
+	assert.NoError(t, err)
+
+	// ValueAsync does not block, it can be subscribed before the DAG is started.
+	fc := prog.ValueAsync[ResultC]()
+	fd := prog.ValueAsync[ResultD]()
+
+	_, err = prog.Run(context.Background())
+	assert.NoError(t, err)
+
+	c, err := fc.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, ResultC{Sum: 15}, c)
+
+	d, err := fd.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, ResultD{Message: "Sum is \x0f"}, d)
+
+	// After the DAG completed, Value returns the very same values.
+	c2, err := prog.Value[ResultC]()
+	assert.NoError(t, err)
+	assert.Equal(t, c, c2)
+
+	// An unregistered type is reported eagerly, without executing anything.
+	_, err = prog.ValueAsync[Unregistered]().Get()
+	assert.ErrorIs(t, err, ErrTypeNotFound)
+
+	// Casting a node result to an unrelated type fails with ErrTypeMismatch.
+	_, err = prog.ValueAsync[ResultC]().Cast[ResultD]().Get()
+	assert.ErrorIs(t, err, future.ErrTypeMismatch)
+}

--- a/doc.go
+++ b/doc.go
@@ -21,9 +21,12 @@
 //
 // A transform that changes the result type has to introduce a type parameter of
 // its own. That was impossible for methods until Go 1.27 added generic methods,
-// which is why these transforms used to live at package scope. They are now
-// methods, and the methods hold the only implementation; the old package-level
-// forms remain as deprecated shims for source compatibility.
+// which is why these transforms originally lived at package scope only.
+//
+// Both forms are now available. The methods are the expressive, chainable form;
+// the package-level functions are the original API and remain fully supported,
+// not deprecated. They are independent implementations rather than shims, see
+// "Build tags" below.
 //
 // A combinator over several Futures has no single receiver, so it stays a
 // function. Java, Scala and friends draw the same line: "zip N futures into
@@ -58,4 +61,22 @@
 //     package therefore returns *Future[R] with a fresh R, and combining
 //     Futures is left to the package-level combinators and to the tuples
 //     subpackage.
+//
+// # Build tags
+//
+// The module declares go 1.18 in go.mod, so it keeps building with Go 1.18
+// through Go 1.26. The generic methods live in files guarded by
+//
+//	//go:build go1.27
+//
+// which is satisfied by the toolchain version, not by the go directive. On
+// Go 1.27 and newer both the methods and the package-level functions exist; on
+// older toolchains only the package-level functions are compiled.
+//
+// This is why the two forms do not delegate to each other: the package-level
+// functions must not depend on a file that may be excluded from the build. The
+// duplicated bodies are small and self-contained.
+//
+// The same guard applies to dagcore.NodeInstance.Cast and to
+// dagfunc.Program.Value / ValueAsync.
 package future

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jizhuozhi/go-future
 
-go 1.27
+go 1.18
 
 require github.com/stretchr/testify v1.9.0
 

--- a/method.go
+++ b/method.go
@@ -1,3 +1,5 @@
+//go:build go1.27
+
 package future
 
 import (

--- a/method_test.go
+++ b/method_test.go
@@ -1,3 +1,5 @@
+//go:build go1.27
+
 package future
 
 import (


### PR DESCRIPTION
## 概述

#15 把泛型方法作为一等 API 引入，同时把 `go.mod` 提到了 1.27，等于要求所有使用者升级工具链。本 PR 在此基础上把泛型方法改为**可选的渐进增强**：`go.mod` 回到 `go 1.18`，泛型方法由 `//go:build go1.27` 门控，Go 1.18–1.26 自动回退到包级函数。

## 背景

`//go:build go1.27` 判定的是**工具链版本而非 `go` 指令**——这点做了实测确认：`go.mod` 写 1.18、工具链 1.27 时，带该 tag 的文件照常编译，泛型方法语法也可用。因此可以既不抬高最低版本，又让新版用户拿到泛型方法。

## 结构

```
api.go              (无 tag)            构造器 + 组合子 + 包级单值变换【独立实现】
method.go           //go:build go1.27   泛型方法【独立实现】
dagcore/cast.go     //go:build go1.27
dagfunc/value.go    //go:build go1.27
```

由此产生两条结果：包级函数不能委托给方法（委托文件可能被整体排除出构建），所以两套各自独立实现，重复的都是几行的小函数；包级函数也不再标 `Deprecated`，它们是 1.18–1.26 上唯一可用的形态。

| 工具链 | 可用形态 |
| --- | --- |
| Go 1.18 – 1.26 | 仅包级函数：`Then(f, cb)`、`Timeout(f, d)` … |
| Go 1.27+ | 两种并存：`f.Then(cb)` 与 `Then(f, cb)` |

## 改动要点

- `go.mod` 1.27 → 1.18
- `method.go` / `method_test.go` 加 `//go:build go1.27`
- `api.go` 的包级变换从委托方法改回独立实现，去掉 `Deprecated` 标记
- `dagcore.NodeInstance.Cast[T]` 移入 `dagcore/cast.go`（带 tag），`dagfunc.Value[T]` / `ValueAsync[T]` 移入 `dagfunc/value.go`（带 tag），测试同步拆出
- `dagcore` / `dagfunc` 内部调用从 `.Then(cb)` 改回 `future.Then(f, cb)`——否则 1.18 构建会直接失败
- `dagfunc` 用 `reflect.TypeOf((*T)(nil)).Elem()` 替代 `reflect.TypeFor[T]()`，避开 `stdversion` vet 对 Go 1.22+ 标准库符号的检查
- CI 加 Go 1.18 / 1.27 矩阵；golangci-lint 与 Codecov 只挂在 1.27 job 上
- README 与 `doc.go` 按新口径重写：Requirements 改回 1.18+，迁移章节从"破坏性升级"改为"渐进增强"

## 版本

`v0.2.0` tag 已从远程删除，#15 与本 PR 会在合并后一起构成 v0.2.0。发版后的最低要求是 Go 1.18，Go 1.27+ 额外获得泛型方法；不存在需要升级工具链的版本。

## 验证

Go 1.27 下 `method.go` / `cast.go` / `value.go` 进入构建，6 个包 `-race` 全绿，golangci-lint v2.13.2 报告 0 issues；Go 1.24 下这三个文件被排除，6 个包仍全部通过。`gofmt -l .` 零输出。CI 的 1.18 job 是新增的，本地只有 1.24 近似验证过。

## 后续约定

1. 新增泛型方法必须放进带 `//go:build go1.27` 的文件，放进 `api.go` 会破坏 1.18 构建。
2. 成对的包级函数与泛型方法需同步修改，编译器不检查两边等价。
3. `go.mod` 声明 1.18，即使文件带 go1.27 tag 也尽量避免 Go 1.22+ 的标准库符号。
